### PR TITLE
Actualizado el fichero /src/latobj.c

### DIFF
--- a/src/latobj.c
+++ b/src/latobj.c
@@ -812,7 +812,10 @@ LATINO_API char *latC_astring(lat_mv *mv, lat_objeto *o) {
     } else if (o->tipo == T_INTEGER) {
         return entero_acadena(getEntero(o));
     } else if (o->tipo == T_CHAR) {
-        return (char)getCaracter(o);
+        static char temp_char[2];
+        temp_char[0] = (char)getCharacter(o);
+        temp_char[1] = '\0';
+        return temp_char;
     } else if (o->tipo == T_STR) {
         return strdup(latC_checar_cadena(mv, o));
     } else if (o->tipo == T_FUN) {

--- a/src/latobj.c
+++ b/src/latobj.c
@@ -813,7 +813,7 @@ LATINO_API char *latC_astring(lat_mv *mv, lat_objeto *o) {
         return entero_acadena(getEntero(o));
     } else if (o->tipo == T_CHAR) {
         static char temp_char[2];
-        temp_char[0] = (char)getCharacter(o);
+        temp_char[0] = (char)getCaracter(o);
         temp_char[1] = '\0';
         return temp_char;
     } else if (o->tipo == T_STR) {


### PR DESCRIPTION
En la línea 815, había un error de sintaxis por la falta de actualización, lo que daba problemas al compilarlo con GCC 15.

Nueva línea:
    ...} else if (o->tipo == T_CHAR) {
        static char temp_char[2];
        temp_char[0] = (char)getCaracter(o);
        temp_char[1] = '\0';
}...